### PR TITLE
fix: add proper type definitions for event handlers

### DIFF
--- a/components/aside.tsx
+++ b/components/aside.tsx
@@ -62,19 +62,19 @@ export const Aside = () => {
         router.push(`?${newSearchParams.toString()}`);
     };
 
-    const handleSortChange = (e: SelectEvent) => {
+    const handleSortChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const value = e.target.value;
         setSelectedSort(value);
         updateQueryString({ sort: value });
     };
 
-    const handleLibraryChange = (e: SelectEvent) => {
+    const handleLibraryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const value = e.target.value;
         setSelectedLibrary(value);
         updateQueryString({ library: value });
     };
 
-    const handleCategoryChange = (e: SelectEvent) => {
+    const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const value = e.target.value;
         setSelectedCategory(value);
         updateQueryString({ category: value });


### PR DESCRIPTION
- Add React.ChangeEvent<HTMLSelectElement> type for select event handlers
- Remove unused SelectEvent interface
- Fix TypeScript build error for implicit any type